### PR TITLE
Portfolioモデルに新たなカラムを作成

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -41,6 +41,7 @@ gem 'devise_token_auth'
 gem 'activestorage-validator'
 gem 'alba'
 gem 'nokogiri'
+gem 'enumerize'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -42,6 +42,7 @@ gem 'activestorage-validator'
 gem 'alba'
 gem 'nokogiri'
 gem 'enumerize'
+gem 'validate_url'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -162,6 +162,7 @@ GEM
     parser (3.2.2.3)
       ast (~> 2.4.1)
       racc
+    public_suffix (5.0.4)
     puma (5.6.5)
       nio4r (~> 2.0)
     racc (1.7.1)
@@ -263,6 +264,9 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.4.2)
+    validate_url (1.0.15)
+      activemodel (>= 3.0.0)
+      public_suffix
     warden (1.2.9)
       rack (>= 2.0.9)
     websocket-driver (0.7.5)
@@ -294,6 +298,7 @@ DEPENDENCIES
   rspec-rails
   rubocop-airbnb
   tzinfo-data
+  validate_url
 
 RUBY VERSION
    ruby 3.2.2p53

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -112,6 +112,8 @@ GEM
       devise (> 3.5.2, < 5)
       rails (>= 4.2.0, < 7.1)
     diff-lcs (1.5.0)
+    enumerize (2.7.0)
+      activesupport (>= 3.2)
     erubi (1.12.0)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
@@ -281,6 +283,7 @@ DEPENDENCIES
   debug
   devise
   devise_token_auth
+  enumerize
   factory_bot_rails
   mysql2 (~> 0.5)
   nokogiri

--- a/backend/app/controllers/api/v1/portfolios/portfolios_controller.rb
+++ b/backend/app/controllers/api/v1/portfolios/portfolios_controller.rb
@@ -87,6 +87,12 @@ class Api::V1::Portfolios::PortfoliosController < ApplicationController
   end
 
   def portfolio_params
-    params.require(:portfolio).permit(:title, :content, :operation_status, :portfolio_site_url)
+    params.require(:portfolio).permit(
+      :title,
+      :content,
+      :operation_status,
+      :portfolio_site_url,
+      :repository_url
+    )
   end
 end

--- a/backend/app/controllers/api/v1/portfolios/portfolios_controller.rb
+++ b/backend/app/controllers/api/v1/portfolios/portfolios_controller.rb
@@ -87,6 +87,6 @@ class Api::V1::Portfolios::PortfoliosController < ApplicationController
   end
 
   def portfolio_params
-    params.require(:portfolio).permit(:title, :content, :operation_status)
+    params.require(:portfolio).permit(:title, :content, :operation_status, :portfolio_site_url)
   end
 end

--- a/backend/app/controllers/api/v1/portfolios/portfolios_controller.rb
+++ b/backend/app/controllers/api/v1/portfolios/portfolios_controller.rb
@@ -87,6 +87,6 @@ class Api::V1::Portfolios::PortfoliosController < ApplicationController
   end
 
   def portfolio_params
-    params.require(:portfolio).permit(:title, :content)
+    params.require(:portfolio).permit(:title, :content, :operation_status)
   end
 end

--- a/backend/app/models/application_record.rb
+++ b/backend/app/models/application_record.rb
@@ -1,3 +1,4 @@
 class ApplicationRecord < ActiveRecord::Base
   primary_abstract_class
+  extend Enumerize
 end

--- a/backend/app/models/portfolio.rb
+++ b/backend/app/models/portfolio.rb
@@ -19,4 +19,7 @@ class Portfolio < ApplicationRecord
   validates :portfolio_site_url,
             presence: true,
             url: true
+
+  validates :repository_url,
+            url: { allow_nil: true }
 end

--- a/backend/app/models/portfolio.rb
+++ b/backend/app/models/portfolio.rb
@@ -10,11 +10,13 @@ class Portfolio < ApplicationRecord
 
   validates :title,
             presence: true,
-            length: { maximum: 25 },
-            on: [:create, :update]
+            length: { maximum: 25 }
 
   validates :content,
-  presence: true,
-  length: { maximum: 255 },
-  on: [:create, :update]
+            presence: true,
+            length: { maximum: 255 }
+
+  validates :portfolio_site_url,
+            presence: true,
+            url: true
 end

--- a/backend/app/models/portfolio.rb
+++ b/backend/app/models/portfolio.rb
@@ -3,6 +3,11 @@ class Portfolio < ApplicationRecord
   has_many :goods, dependent: :delete_all
   has_many :comments, dependent: :delete_all
 
+  enumerize :operation_status,
+            in: { active: 0, maintenance: 1, inactive: 2 },
+            default: :active,
+            predicates: :true, scope: :true
+
   validates :title,
             presence: true,
             length: { maximum: 25 },

--- a/backend/db/migrate/20240201183908_add_operation_status_to_portfolios.rb
+++ b/backend/db/migrate/20240201183908_add_operation_status_to_portfolios.rb
@@ -1,0 +1,7 @@
+class AddOperationStatusToPortfolios < ActiveRecord::Migration[7.0]
+  def change
+    add_column :portfolios, :operation_status, :integer, default: 0, null: false
+
+    add_check_constraint :portfolios, 'operation_status IN (0, 1, 2)', name: 'check_portfolios_on_operation_status'
+  end
+end

--- a/backend/db/migrate/20240202200230_add_portfolio_site_url_to_portfolios.rb
+++ b/backend/db/migrate/20240202200230_add_portfolio_site_url_to_portfolios.rb
@@ -1,0 +1,5 @@
+class AddPortfolioSiteUrlToPortfolios < ActiveRecord::Migration[7.0]
+  def change
+    add_column :portfolios, :portfolio_site_url, :string, null: false
+  end
+end

--- a/backend/db/migrate/20240202220228_add_repository_url_to_portfolios.rb
+++ b/backend/db/migrate/20240202220228_add_repository_url_to_portfolios.rb
@@ -1,0 +1,5 @@
+class AddRepositoryUrlToPortfolios < ActiveRecord::Migration[7.0]
+  def change
+    add_column :portfolios, :repository_url, :string
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_12_234513) do
+ActiveRecord::Schema[7.0].define(version: 2024_02_01_183908) do
   create_table "active_storage_attachments", charset: "utf8mb4", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -74,6 +74,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_12_234513) do
     t.integer "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "operation_status", default: 0, null: false
   end
 
   create_table "tags", charset: "utf8mb4", force: :cascade do |t|

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_02_02_200230) do
+ActiveRecord::Schema[7.0].define(version: 2024_02_02_220228) do
   create_table "active_storage_attachments", charset: "utf8mb4", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -76,6 +76,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_02_200230) do
     t.datetime "updated_at", null: false
     t.integer "operation_status", default: 0, null: false
     t.string "portfolio_site_url", null: false
+    t.string "repository_url"
   end
 
   create_table "tags", charset: "utf8mb4", force: :cascade do |t|

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_02_01_183908) do
+ActiveRecord::Schema[7.0].define(version: 2024_02_02_200230) do
   create_table "active_storage_attachments", charset: "utf8mb4", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -75,6 +75,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_01_183908) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "operation_status", default: 0, null: false
+    t.string "portfolio_site_url", null: false
   end
 
   create_table "tags", charset: "utf8mb4", force: :cascade do |t|

--- a/backend/spec/factories/portfolios.rb
+++ b/backend/spec/factories/portfolios.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :portfolio do
     title { "testTitle" }
     content { "testContent" }
+    operation_status { "active" }
     user
   end
 end

--- a/backend/spec/factories/portfolios.rb
+++ b/backend/spec/factories/portfolios.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     title { "testTitle" }
     content { "testContent" }
     operation_status { "active" }
+    portfolio_site_url { "http://example.com" }
     user
   end
 end

--- a/backend/spec/factories/portfolios.rb
+++ b/backend/spec/factories/portfolios.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
     content { "testContent" }
     operation_status { "active" }
     portfolio_site_url { "http://example.com" }
+    repository_url { nil }
     user
   end
 end

--- a/backend/spec/models/portfolio_spec.rb
+++ b/backend/spec/models/portfolio_spec.rb
@@ -29,5 +29,14 @@ RSpec.describe Portfolio, type: :model do
         expect(portfolio.errors[:content]).to include("is too long (maximum is 255 characters)")
       end
     end
+
+    describe "operation_status" do
+      it "operation_statusは範囲内の数値である必要がある" do
+        invalid_operation_status = 3
+        portfolio = Portfolio.new(operation_status: invalid_operation_status)
+        expect(portfolio).not_to be_valid
+        expect(portfolio.errors[:operation_status]).to include("is not included in the list")
+      end
+    end
   end
 end

--- a/backend/spec/models/portfolio_spec.rb
+++ b/backend/spec/models/portfolio_spec.rb
@@ -38,5 +38,13 @@ RSpec.describe Portfolio, type: :model do
         expect(portfolio.errors[:operation_status]).to include("is not included in the list")
       end
     end
+
+    describe "portfolio_site_url" do
+      it "portfolio_site_urlが存在する必要がある" do
+        portfolio = Portfolio.new(portfolio_site_url: nil)
+        expect(portfolio).not_to be_valid
+        expect(portfolio.errors[:portfolio_site_url]).to include("can't be blank")
+      end
+    end
   end
 end

--- a/backend/spec/rails_helper.rb
+++ b/backend/spec/rails_helper.rb
@@ -2,6 +2,7 @@
 require 'spec_helper'
 require 'support/auth_helpers'
 require 'database_cleaner/active_record'
+require 'validate_url/rspec_matcher'
 
 ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'

--- a/backend/spec/requests/api/v1/portfolios/portfolios_spec.rb
+++ b/backend/spec/requests/api/v1/portfolios/portfolios_spec.rb
@@ -20,7 +20,12 @@ RSpec.describe "Api::V1::Portfolios::Portfolios", type: :request do
 
   describe "POST /portfolios" do
     let(:valid_portfolio_params) do
-      { title: "testTitle", content: "testContent", operation_status: "0" }
+      {
+        title: "testTitle",
+        content: "testContent",
+        operation_status: "0",
+        portfolio_site_url: "http://example.com",
+      }
     end
     let(:invalid_portfolio_params) { valid_portfolio_params.merge(title: "") }
     let(:invalid_portfolio_operation_status_params) do

--- a/backend/spec/requests/api/v1/portfolios/portfolios_spec.rb
+++ b/backend/spec/requests/api/v1/portfolios/portfolios_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe "Api::V1::Portfolios::Portfolios", type: :request do
         content: "testContent",
         operation_status: "0",
         portfolio_site_url: "http://example.com",
+        repository_url: "http://example.com",
       }
     end
     let(:invalid_portfolio_params) { valid_portfolio_params.merge(title: "") }


### PR DESCRIPTION
・運用状況を示す`operation_status`
・ポートフォリオサイトのURLを示す`portfolio_site_url`
・ポートフォリオのリポジトリーサイトを示す`repository_url`
を作成
URLのバリデーションのために`validate_url`を、enumを使用しやすくするために`enumerize`を導入