### PR TITLE
Refactor article goods

### DIFF
--- a/backend/app/controllers/api/v1/articles/articles_controller.rb
+++ b/backend/app/controllers/api/v1/articles/articles_controller.rb
@@ -4,7 +4,7 @@ class Api::V1::Articles::ArticlesController < ApplicationController
   before_action :authorize_user_for_article!, only: [:update, :destroy]
 
   def index
-    articles = Article.includes(:goods, :comments, user: { image_attachment: :blob }).
+    articles = Article.includes(:comments, user: { image_attachment: :blob }).
       order(updated_at: :desc)
 
     render json: Articles::ArticleResource.new(articles).serializable_hash,

--- a/backend/app/controllers/api/v1/articles/goods_controller.rb
+++ b/backend/app/controllers/api/v1/articles/goods_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::Articles::GoodsController < ApplicationController
-  before_action :authenticate_api_v1_user!, only: [:create, :destroy]
+  before_action :authenticate_api_v1_user!, only: [:create, :destroy, :check]
 
   def create
     good = Good.new(user_id: current_api_v1_user.id, article_id: params[:article_id])
@@ -24,5 +24,12 @@ class Api::V1::Articles::GoodsController < ApplicationController
     good = Good.find_by!(user_id: current_api_v1_user.id, article_id: params[:article_id])
     good.destroy
     render json: { status: 'success', message: 'Good destroyed' }, status: :ok
+  end
+
+  def check
+    article_id = params[:article_id].to_i
+    is_liked = current_api_v1_user.goods.exists?(article_id: article_id)
+    render json: { is_liked: is_liked },
+           status: :ok
   end
 end

--- a/backend/app/controllers/api/v1/articles/latest_articles_controller.rb
+++ b/backend/app/controllers/api/v1/articles/latest_articles_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::Articles::LatestArticlesController < ApplicationController
   def index
-    articles = Article.includes(:goods, :comments, user: { image_attachment: :blob }).
+    articles = Article.includes(:comments, user: { image_attachment: :blob }).
       order(updated_at: :desc).
       limit(3)
 

--- a/backend/app/controllers/api/v1/articles/popular_articles_controller.rb
+++ b/backend/app/controllers/api/v1/articles/popular_articles_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::Articles::PopularArticlesController < ApplicationController
   def index
-    articles = Article.includes(:goods, :comments, user: { image_attachment: :blob }).
+    articles = Article.includes(:comments, user: { image_attachment: :blob }).
       left_joins(:goods).
       group(:id).
       order('COUNT(goods.id) DESC').

--- a/backend/app/controllers/api/v1/articles/user_articles_controller.rb
+++ b/backend/app/controllers/api/v1/articles/user_articles_controller.rb
@@ -2,7 +2,7 @@ class Api::V1::Articles::UserArticlesController < ApplicationController
   before_action :set_user_id, only: [:index]
 
   def index
-    user = User.includes(:articles, { articles: [:goods, :comments] }, image_attachment: :blob).
+    user = User.includes(:articles, { articles: [:comments] }, image_attachment: :blob).
       find_by(id: @user_id)
 
     if user.nil?

--- a/backend/app/models/good.rb
+++ b/backend/app/models/good.rb
@@ -1,6 +1,6 @@
 class Good < ApplicationRecord
   belongs_to :user
-  belongs_to :article
+  belongs_to :article, counter_cache: :total_likes
 
   validates :user_id, uniqueness: { scope: :article_id }
 end

--- a/backend/app/resources/articles/article_resource.rb
+++ b/backend/app/resources/articles/article_resource.rb
@@ -9,13 +9,10 @@ class Articles::ArticleResource
              :operation_status,
              :portfolio_site_url,
              :repository_url,
+             :total_likes,
              :updated_at
 
   one :user, resource: Users::UserResource
-
-  many :goods do
-    attributes :user_id
-  end
 
   many :comments, resource: Comments::CommentResource
 end

--- a/backend/app/resources/users/auth_resource.rb
+++ b/backend/app/resources/users/auth_resource.rb
@@ -9,10 +9,6 @@ class Users::AuthResource
     user.image_url
   end
 
-  many :goods do
-    attributes :article_id
-  end
-
   many :comments do
     attributes :content, :updated_at
 

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -18,7 +18,9 @@ Rails.application.routes.draw do
 
       scope module: "articles" do
         resources :articles do
-          resource :goods, only: [:create, :destroy]
+          resource :goods, only: [:create, :destroy] do
+            get "check", on: :collection
+          end
           resources :comments, only: [:create, :update, :destroy]
         end
         resources :user_articles, only: [:index]

--- a/backend/db/migrate/20240307133939_add_total_likes_to_articles.rb
+++ b/backend/db/migrate/20240307133939_add_total_likes_to_articles.rb
@@ -1,0 +1,5 @@
+class AddTotalLikesToArticles < ActiveRecord::Migration[7.0]
+  def change
+    add_column :articles, :total_likes, :integer, default: 0, null: false
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_02_23_172236) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_07_133939) do
   create_table "active_storage_attachments", charset: "utf8mb4", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -48,6 +48,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_23_172236) do
     t.integer "operation_status", default: 0, null: false
     t.string "portfolio_site_url", null: false
     t.string "repository_url"
+    t.integer "total_likes", default: 0, null: false
   end
 
   create_table "comments", charset: "utf8mb4", force: :cascade do |t|

--- a/backend/spec/requests/api/v1/articles/goods_spec.rb
+++ b/backend/spec/requests/api/v1/articles/goods_spec.rb
@@ -83,4 +83,26 @@ RSpec.describe "Api::V1::Articles::Goods", type: :request do
       end
     end
   end
+
+  describe "GET /goods/check" do
+    context "すでにいいね済みの場合" do
+      let!(:good) { create(:good, user: user, article: article) }
+
+      it "is_likedはtrueである" do
+        get "/api/v1/articles/#{article.id}/goods/check", headers: auth_headers
+        expect(response).to have_http_status(:ok)
+        json_response = JSON.parse(response.body)
+        expect(json_response["is_liked"]).to be true
+      end
+    end
+
+    context "いいねされていない場合" do
+      it "is_likedはfalseである" do
+        get "/api/v1/articles/#{article.id}/goods/check", headers: auth_headers
+        expect(response).to have_http_status(:ok)
+        json_response = JSON.parse(response.body)
+        expect(json_response["is_liked"]).to be false
+      end
+    end
+  end
 end

--- a/backend/spec/requests/api/v1/auth/sessions_spec.rb
+++ b/backend/spec/requests/api/v1/auth/sessions_spec.rb
@@ -109,7 +109,6 @@ RSpec.describe "Api::V1::Auth::Sessions", type: :request do
             "id" => user.id,
             "name" => user.name,
             "image" => user.image_url,
-            "goods" => user.goods,
             "comments" => user.comments,
             "role" => "user",
           },

--- a/frontend/app/__tests__/fixtures/articles/validArticleData.ts
+++ b/frontend/app/__tests__/fixtures/articles/validArticleData.ts
@@ -9,9 +9,9 @@ export const validArticleData: ArticleData = {
   operationStatus: "active",
   portfolioSiteUrl: "http://example.cpm",
   repositoryUrl: "http://example.com",
+  totalLikes: 3,
   updatedAt: new Date(),
   user: validUserData,
-  goods: [{ userId: 1 }, { userId: 2 }, { userId: 3 }],
   comments: [
     {
       id: 1,

--- a/frontend/app/__tests__/fixtures/auth/validUserData.ts
+++ b/frontend/app/__tests__/fixtures/auth/validUserData.ts
@@ -5,6 +5,5 @@ export const validUserData: UserData = {
   name: "testuser",
   role: "user",
   image: "/defaultUserImage.png",
-  goods: [],
   comments: []
 };

--- a/frontend/app/app/features/articles/_likes/hooks/useGetIsLiked.ts
+++ b/frontend/app/app/features/articles/_likes/hooks/useGetIsLiked.ts
@@ -1,0 +1,12 @@
+import { useSWRWithAxiosAndAuth } from "@/app/hooks/swr/useSWRWithAxiosAndAuth";
+
+interface Response {
+  isLiked: boolean;
+}
+export const useGetIsLiked = (articleId: number) => {
+  const endpoint = `/articles/${articleId}/goods/check`;
+  const { responseData, ...other } = useSWRWithAxiosAndAuth<Response>(endpoint, {
+    errorRetryCount: 2
+  });
+  return { initialLiked: responseData?.isLiked, ...other };
+};

--- a/frontend/app/app/features/articles/_likes/hooks/useToggleArticleGood.ts
+++ b/frontend/app/app/features/articles/_likes/hooks/useToggleArticleGood.ts
@@ -58,7 +58,7 @@ export const useToggleLikeArticleGood = (articleData: ArticleData) => {
     void debouncedToggle();
   };
 
-  let totalLiked = articleData.goods.length;
+  let totalLiked = articleData.totalLikes;
 
   switch (initialLiked) {
     case true:

--- a/frontend/app/app/features/articles/api/__tests__/postArticle.test.ts
+++ b/frontend/app/app/features/articles/api/__tests__/postArticle.test.ts
@@ -1,3 +1,4 @@
+import { validArticleData } from "@/__tests__/fixtures/articles/validArticleData";
 import { validPostArticleData } from "@/__tests__/fixtures/articles/validPostArticleData";
 import { mockUnauthorizedResponse } from "@/__tests__/fixtures/auth/unauthorizedResponseData";
 import { mockUnexpectedResponse } from "@/__tests__/fixtures/unexpectedResponseData";
@@ -7,10 +8,7 @@ import { UNEXPECTED_ERROR_MESSAGE } from "@/app/constants/errors/Messages";
 
 import { postArticle } from "../postArticle";
 
-import type {
-  PostArticleFailedData,
-  PostArticleSuccessData
-} from "../../types/api/postArticle";
+import type { PostArticleFailedData } from "../../types/api/postArticle";
 
 jest.mock("@/app/libs/cookie/loadAuthInfo", () => mockAddAuthInfoToRequest);
 jest.mock("@/app/libs/axios/api", () => mockApi);
@@ -25,17 +23,12 @@ describe("postArticle", () => {
   });
 
   describe("リクエストに成功した時", () => {
-    const mockPostPortfoliosByIdSuccessData: PostArticleSuccessData = {
-      status: "success",
-      message: "successMessage"
-    };
-
-    const mockPostPortfoliosSuccessResponse = {
-      data: mockPostPortfoliosByIdSuccessData
+    const mockPostArticlesSuccessResponse = {
+      data: validArticleData
     };
 
     it("エラーをスローしない", async () => {
-      mockPost.mockResolvedValue(mockPostPortfoliosSuccessResponse);
+      mockPost.mockResolvedValue(mockPostArticlesSuccessResponse);
       await expect(postArticle(validPostArticleData)).resolves.not.toThrow();
     });
   });
@@ -53,7 +46,7 @@ describe("postArticle", () => {
       });
 
       describe("レスポンスデータの型がPatchPortfoliosByIdFailedDataを満たす場合", () => {
-        const mockPostPortfoliosFailedData: PostArticleFailedData = {
+        const mockPostArticlesFailedData: PostArticleFailedData = {
           status: "error",
           message: "failed",
           errors: ["failed"]
@@ -61,7 +54,7 @@ describe("postArticle", () => {
 
         const mockPostPortfoliosFailedResponse = {
           response: {
-            data: mockPostPortfoliosFailedData
+            data: mockPostArticlesFailedData
           }
         };
 
@@ -69,7 +62,7 @@ describe("postArticle", () => {
           mockAxios.isAxiosError.mockReturnValue(true);
           mockPost.mockRejectedValue(mockPostPortfoliosFailedResponse);
           await expect(postArticle(validPostArticleData)).rejects.toThrow(
-            mockPostPortfoliosFailedData.errors.join(", ")
+            mockPostArticlesFailedData.errors.join(", ")
           );
         });
       });

--- a/frontend/app/app/features/articles/components/ArticleCard/index.tsx
+++ b/frontend/app/app/features/articles/components/ArticleCard/index.tsx
@@ -23,7 +23,7 @@ interface Props {
 }
 
 const ArticleCard: React.FC<Props> = ({ articleData }) => {
-  const { id, title, updatedAt, user, goods } = articleData;
+  const { id, title, updatedAt, user, totalLikes } = articleData;
 
   return (
     <Card w="full" h="auto" as={NextLink} href={`/articles/${id}`}>
@@ -39,7 +39,7 @@ const ArticleCard: React.FC<Props> = ({ articleData }) => {
       <CardFooter alignItems="center" justifyContent="space-between">
         <Flex alignItems="center" color="blackAlpha.500" gap="1">
           <Icon as={AiOutlineHeart} />
-          <Text>{goods.length}</Text>
+          <Text>{totalLikes}</Text>
         </Flex>
         <UpdatedDateText date={updatedAt} />
       </CardFooter>

--- a/frontend/app/app/features/articles/types/articleData.ts
+++ b/frontend/app/app/features/articles/types/articleData.ts
@@ -2,10 +2,6 @@ import type { CommentData } from "../_comments/types";
 import type { candidateOperationStatusData } from "@/app/constants/datas/portfolios/operationStatuses";
 import type { UserData } from "@/app/types/auth";
 
-interface Good {
-  userId: number;
-}
-
 type OperationStatus = keyof typeof candidateOperationStatusData;
 
 export interface ArticleData {
@@ -16,7 +12,7 @@ export interface ArticleData {
   portfolioSiteUrl: string;
   repositoryUrl: string | null;
   updatedAt: Date;
+  totalLikes: number;
   user: UserData;
-  goods: Good[];
   comments: CommentData[];
 }

--- a/frontend/app/app/types/auth.ts
+++ b/frontend/app/app/types/auth.ts
@@ -2,10 +2,6 @@ import type { CommentTagData } from "../features/articles/_comments/types";
 import type { UnauthorizedResponseDataSchema } from "../libs/zod/apiErrorResponses/auth/responseDataSchema";
 import type { z } from "zod";
 
-interface Good {
-  articleId: number;
-}
-
 interface Article {
   id: number;
   title: string;
@@ -22,7 +18,6 @@ export interface UserData {
   name: string;
   role: "user" | "guest";
   image: string;
-  goods: Good[];
   comments: Comment[];
 }
 


### PR DESCRIPTION
- いいねしているかどうかを返すAPI `GET /articles/:id/goods/check`を作成
- セッション認証時にいいねした投稿idを返さないように変更
- `Article`に いいね数を示す`total_likes`カラムを作成