### PR TITLE
Update/validation rules relaxation

### DIFF
--- a/backend/app/models/article.rb
+++ b/backend/app/models/article.rb
@@ -10,7 +10,7 @@ class Article < ApplicationRecord
 
   validates :title,
             presence: true,
-            length: { maximum: 25 }
+            length: { maximum: 75 }
 
   validates :content,
             presence: true,

--- a/backend/spec/factories/articles.rb
+++ b/backend/spec/factories/articles.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :article do
-    title { Faker::Lorem.sentence(word_count: 3).truncate(25) }
+    title { Faker::Lorem.sentence(word_count: 11).truncate(75) }
     content { Faker::Lorem.paragraph(sentence_count: 5).truncate(255) }
     operation_status { Article.operation_status.values.sample }
     portfolio_site_url { Faker::Internet.url }

--- a/backend/spec/models/article_spec.rb
+++ b/backend/spec/models/article_spec.rb
@@ -9,10 +9,10 @@ RSpec.describe Article, type: :model do
         expect(article.errors[:title]).to include("can't be blank")
       end
 
-      it "titleの長さは25文字以内である必要がある" do
-        article = Article.new(title: 'a' * 26)
+      it "titleの長さは75文字以内である必要がある" do
+        article = Article.new(title: 'a' * 76)
         expect(article).not_to be_valid
-        expect(article.errors[:title]).to include("is too long (maximum is 25 characters)")
+        expect(article.errors[:title]).to include("is too long (maximum is 75 characters)")
       end
     end
 

--- a/frontend/app/app/features/articles/hooks/__tests__/articleSchema.test.ts
+++ b/frontend/app/app/features/articles/hooks/__tests__/articleSchema.test.ts
@@ -38,8 +38,8 @@ describe("ArticleSchema", () => {
       expect(titleErrors[0]).toBe(ArticleValidationErrorMessages.titleRequired);
     });
 
-    it("titleが26文字以上の時、正しいエラーメッセージをスローする", () => {
-      const invalidTitleData = { ...validPostArticleData, title: "a".repeat(26) };
+    it("titleが76文字以上の時、正しいエラーメッセージをスローする", () => {
+      const invalidTitleData = { ...validPostArticleData, title: "a".repeat(76) };
       expect(() => ArticleSchema.parse(invalidTitleData)).toThrow(ZodError);
       const titleErrors = validationErrorMessages(invalidTitleData, "title");
       expect(titleErrors[0]).toBe(ArticleValidationErrorMessages.titleTooLong);

--- a/frontend/app/app/features/articles/hooks/articleSchema.ts
+++ b/frontend/app/app/features/articles/hooks/articleSchema.ts
@@ -17,7 +17,7 @@ export const ArticleSchema = z.object({
   title: z
     .string()
     .min(1, ArticleValidationErrorMessages.titleRequired)
-    .max(25, ArticleValidationErrorMessages.titleTooLong),
+    .max(75, ArticleValidationErrorMessages.titleTooLong),
   content: z
     .string()
     .min(1, ArticleValidationErrorMessages.contentRequired)

--- a/frontend/app/app/features/articles/hooks/messages.ts
+++ b/frontend/app/app/features/articles/hooks/messages.ts
@@ -1,6 +1,6 @@
 export const ArticleValidationErrorMessages = {
   titleRequired: "タイトルを入力してください",
-  titleTooLong: "タイトルは25文字以内である必要があります",
+  titleTooLong: "タイトルは75文字以内である必要があります",
   contentRequired: "本文を入力してください",
   contentTooLong: "本文は255文字以内である必要があります",
   changeRequired: "タイトルまたは本文を変更してください",


### PR DESCRIPTION
- `Article`の`title`カラムのバリデーションを75文字以内に緩和